### PR TITLE
Add support for passing config to auth functions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "redux-thunk": "^2.1.0"
   },
   "dependencies": {
-    "solid-client": "^0.22.4"
+    "solid-auth-tls": "^0.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,4 +1,4 @@
-import solid from 'solid-client'
+import { login, currentUser } from 'solid-auth-tls'
 
 import {
   AUTH_REQUEST,
@@ -6,25 +6,14 @@ import {
   AUTH_FAILURE
 } from './action-types'
 
-export function authenticate () {
-  return dispatch => {
-    dispatch(request())
-    return solid.login()
-      .then(webId => {
-        dispatch(success(webId))
-        return webId
-      })
-      .catch(error => {
-        dispatch(failure(error))
-        throw error
-      })
-  }
-}
+export const authenticate = config => authAction(login, config)
 
-export function checkAuthenticated () {
+export const checkAuthenticated = config => authAction(currentUser, config)
+
+function authAction (authFn, config) {
   return dispatch => {
     dispatch(request())
-    return solid.currentUser()
+    return authFn(config)
       .then(webId => {
         dispatch(success(webId))
         return webId

--- a/test/actions.spec.js
+++ b/test/actions.spec.js
@@ -21,7 +21,7 @@ describe('auth actions', () => {
     const currentUserSpy = spy(currentUser)
     const loginSpy = spy(login)
     const InjectedActions = proxyquire('../src/actions', {
-      'solid-client': {
+      'solid-auth-tls': {
         currentUser: currentUserSpy,
         login: loginSpy
       }
@@ -63,6 +63,20 @@ describe('auth actions', () => {
           expect(err).toEqual(error)
         })
     })
+
+    it('passes a configuration object to the login function if provided', () => {
+      const {loginSpy, InjectedActions} = injectSolidWith({
+        login: () => Promise.resolve()
+      })
+      return InjectedActions.authenticate()(dispatchSpy)
+        .then(() => {
+          expect(loginSpy.calledWithExactly(undefined)).toBe(true)
+        })
+        .then(InjectedActions.authenticate({ foo: 'bar' })(dispatchSpy))
+        .then(() => {
+          expect(loginSpy.calledWithExactly({ foo: 'bar' })).toBe(true)
+        })
+    })
   })
 
   describe('checkAuthenticated', () => {
@@ -97,6 +111,20 @@ describe('auth actions', () => {
             error
           }))
           expect(err).toEqual(error)
+        })
+    })
+
+    it('passes a configuration object to the currentUser function if provided', () => {
+      const {currentUserSpy, InjectedActions} = injectSolidWith({
+        currentUser: () => Promise.resolve()
+      })
+      return InjectedActions.checkAuthenticated()(dispatchSpy)
+        .then(() => {
+          expect(currentUserSpy.calledWithExactly(undefined)).toBe(true)
+        })
+        .then(InjectedActions.checkAuthenticated({ foo: 'bar' })(dispatchSpy))
+        .then(() => {
+          expect(currentUserSpy.calledWithExactly({ foo: 'bar' })).toBe(true)
         })
     })
   })


### PR DESCRIPTION
Updates the auth library to the solid-auth-tls@0.1.0 which adds initial support
for authenticating node clients.

Also adds `config` parameters to `authenticate` and `checkAuthenticated` which
get passed to solid-auth-tls's `login` and `currentUser`, respectively.